### PR TITLE
Added #[only_guilds] command attribute and vendored-openssl feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1331,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1350,6 +1360,7 @@ dependencies = [
  "lazy_static",
  "log",
  "once_cell",
+ "openssl",
  "parking_lot",
  "prometheus",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,10 @@ twilight-gateway = "0.6.2"
 twilight-http = "0.6"
 twilight-model = "0.6"
 twilight-standby = "0.6"
+
+[features]
+vendored-openssl = ["openssl/vendored"]
+
+[dependencies.openssl]
+version = "0.10"
+optional = true

--- a/slash_command_macro/src/lib.rs
+++ b/slash_command_macro/src/lib.rs
@@ -21,6 +21,7 @@ use syn::{
 /// - `#[options = "..."]` for the function name that returns the command options as `Vec<CommandOption>`.
 /// If none is specified the defined command won't have options.
 /// - `#[run = "..."` for the function name that runs the command. Defaults to the lowercase struct name.
+/// - `#[only_guilds]` to mark commands as disabled in DMs
 ///
 /// For a given command struct `C` this macro enables:
 /// - `C::NAME -> &'static str` for the command name
@@ -51,6 +52,7 @@ use syn::{
 /// #[name = "roll_command"]
 /// #[options = "roll_options"]
 /// #[run = "my_roll_fn"]
+/// #[only_guilds]
 /// pub struct Roll;
 ///
 /// struct RollArgs { limit: u64 }


### PR DESCRIPTION
Commands can now be attributed with `#[only_guilds]`. If users use one of such commands in DMs the bot will automatically respond with "This command is not available in DMs".

Also added the `vendored-openssl` feature for later.